### PR TITLE
Use the correct cookbook name for the Supermarket badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hashicorp-vault cookbook
 
-[![Cookbook Version](https://img.shields.io/cookbook/v/vault.svg)](https://supermarket.chef.io/cookbooks/vault)
+[![Cookbook Version](https://img.shields.io/cookbook/v/vault.svg)](https://supermarket.chef.io/cookbooks/hashicorp-vault)
 [![Build Status](https://img.shields.io/circleci/project/github/sous-chefs/vault/master.svg)](https://circleci.com/gh/sous-chefs/vault)
 
 [Application cookbook][0] for installing and configuring [Hashicorp Vault][1].


### PR DESCRIPTION
# Description

- cookbook name is hashicorp-vault rather than vault

## Issues Resolved

Correct the badge in the README.

## Check List

- [x] All tests pass. See TESTING.md for details
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
