### PR TITLE
Changing the name of conflicting unused helper function names

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -34,11 +34,11 @@ module VaultCookbook
       join_path('C:', 'Program Files') + (arch_64? ? '' : ' x(86)')
     end
 
-    def config_prefix_path
+    def vault_config_prefix_path
       windows? ? join_path(program_files, 'vault') : join_path('/etc', 'vault')
     end
 
-    def data_path
+    def vault_data_path
       windows? ? join_path(program_files, 'vault', 'data') : join_path('/var/lib', 'vault')
     end
   end


### PR DESCRIPTION
# Description

The functions `config_prefix_path` and `data_path` are exists on both ![Vault](https://github.com/sous-chefs/vault/blob/master/libraries/helpers.rb#L37-L43) and ![Consul](https://github.com/sous-chefs/consul/blob/master/libraries/helpers.rb#L39-L45) cookbooks and they conflicting with each other.
Both gets the config and data path like vault functions get `config_prefix_path=/etc/vault` whereas consul get `config_prefix_path=/etc/consul`. Whichever runs last is getting precedence. 

In my case, vault runs later. So the `config_prefix_path` of consul is changed to `/etc/vault` instead of `/etc/consul`
```
       Recipe: consul::default
         * poise_service_user[consul] action create[2019-06-10T17:49:10+01:00] INFO: Processing poise_service_user[consul] action create (consul::default line 7)
       [2019-06-10T17:49:10+01:00] INFO: Processing poise_service_user[consul] action create (consul::default line 7)

           * group[consul] action create[2019-06-10T17:49:10+01:00] INFO: Processing group[consul] action create (/tmp/kitchen/cache/cookbooks/poise-service/files/halite_gem/poise_service/resources/poise_service_user.rb line 141)
       [2019-06-10T17:49:10+01:00] INFO: Processing group[consul] action create (/tmp/kitchen/cache/cookbooks/poise-service/files/halite_gem/poise_service/resources/poise_service_user.rb line 141)
        (up to date)
           * linux_user[consul] action create[2019-06-10T17:49:10+01:00] INFO: Processing linux_user[consul] action create (/tmp/kitchen/cache/cookbooks/poise-service/files/halite_gem/poise_service/resources/poise_service_user.rb line 153)
       [2019-06-10T17:49:10+01:00] INFO: Processing linux_user[consul] action create (/tmp/kitchen/cache/cookbooks/poise-service/files/halite_gem/poise_service/resources/poise_service_user.rb line 153)
        (up to date)
            (up to date)
         * consul_config[consul] action create[2019-06-10T17:49:10+01:00] INFO: Processing consul_config[consul] action create (consul::default line 16)
       [2019-06-10T17:49:10+01:00] INFO: Processing consul_config[consul] action create (consul::default line 16)

           * directory[/etc/vault] action create[2019-06-10T17:49:10+01:00] INFO: Processing directory[/etc/vault] action create (/tmp/kitchen/cache/cookbooks/consul/libraries/consul_config.rb line 242)
       [2019-06-10T17:49:10+01:00] INFO: Processing directory[/etc/vault] action create (/tmp/kitchen/cache/cookbooks/consul/libraries/consul_config.rb line 242)
        (up to date)
           * directory[/etc/vault/conf.d] action create[2019-06-10T17:49:10+01:00] INFO: Processing directory[/etc/vault/conf.d] action create (/tmp/kitchen/cache/cookbooks/consul/libraries/consul_config.rb line 242)
       [2019-06-10T17:49:10+01:00] INFO: Processing directory[/etc/vault/conf.d] action create (/tmp/kitchen/cache/cookbooks/consul/libraries/consul_config.rb line 242)
        (up to date)
           * file[/etc/vault/consul.json] action create[2019-06-10T17:49:10+01:00] INFO: Processing file[/etc/vault/consul.json] action create (/tmp/kitchen/cache/cookbooks/consul/libraries/consul_config.rb line 253)
       [2019-06-10T17:49:10+01:00] INFO: Processing file[/etc/vault/consul.json] action create (/tmp/kitchen/cache/cookbooks/consul/libraries/consul_config.rb line 253)
        (up to date)
            (up to date)
         * consul_installation[1.1.0] action create[2019-06-10T17:49:10+01:00] INFO: Processing consul_installation[1.1.0] action create (consul::default line 21)
       [2019-06-10T17:49:10+01:00] INFO: Processing consul_installation[1.1.0] action create (consul::default line 21)
```

Changing the name of the function in Vault cookbook instead of Consul as they are not being used in this cookbook ;)

## Check List

- [x] All tests pass. See TESTING.md for details
- NA New functionality includes testing.
- NA New functionality has been documented in the README if applicable
