### PR TITLE
Added bility to tune LimitNOFILE to fix #190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Added
+
+- Resource config now supports property `max_open_files` to tune LimitNOFILE in Systemd unit file. Value is 16384 by default.
+
 ## v4.0.1 (2020-02-20)
 
 ## Added

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -147,7 +147,7 @@ property :ui, [true, false],
          description: 'Enables the built-in web UI, which is available on all listeners (address + port) at the /ui path. Browsers accessing the standard Vault API address will automatically redirect there. This can also be provided via the environment variable VAULT_UI. For more information, please see the ui configuration documentation.'
 
 property :max_open_files, Integer,
-         default: 16384
+         default: 16384,
          description: 'Max open file descriptors than can be used by Vault'
 
 property :pid_file, String,

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -146,6 +146,10 @@ property :ui, [true, false],
          default: false,
          description: 'Enables the built-in web UI, which is available on all listeners (address + port) at the /ui path. Browsers accessing the standard Vault API address will automatically redirect there. This can also be provided via the environment variable VAULT_UI. For more information, please see the ui configuration documentation.'
 
+property :max_open_files, Integer,
+         default: 16384
+         description: 'Max open file descriptors than can be used by Vault'
+
 property :pid_file, String,
          description: ' Path to the file in which the Vault server\'s Process ID (PID) should be stored.'
 property :api_addr, String,

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -150,6 +150,10 @@ property :max_lease_ttl, String,
          default: '768h',
          description: 'Specifies the maximum possible lease duration for tokens and secrets. This is specified using a label suffix like "30s" or "1h".'
 
+property :max_open_files, Integer,
+         default: 16384,
+         description: 'Max open file descriptors than can be used by Vault'
+
 property :default_max_request_duration, String,
          default: '90s',
          description: 'Specifies the default maximum request duration allowed before Vault cancels the request. This can be overridden per listener via the max_request_duration value.'
@@ -302,6 +306,7 @@ action :install do
     vault_user new_resource.vault_user
     vault_group new_resource.vault_group
     config_location new_resource.config_location
+    max_open_files new_resource.max_open_files
     action [:create, :start]
   end
 end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -268,7 +268,6 @@ action :install do
     ha_storage new_resource.ha_storage
     log_level new_resource.log_level
     max_lease_ttl new_resource.max_lease_ttl
-    max_open_files new_resource.max_open_files
     pid_file new_resource.pid_file
     plugin_directory new_resource.plugin_directory
     raw_storage_endpoint new_resource.raw_storage_endpoint

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -162,6 +162,10 @@ property :ui, [true, false],
          default: false,
          description: 'Enables the built-in web UI, which is available on all listeners (address + port) at the /ui path. Browsers accessing the standard Vault API address will automatically redirect there. This can also be provided via the environment variable VAULT_UI. For more information, please see the ui configuration documentation.'
 
+property :max_open_files, Integer,
+         default: 16384,
+         description: 'Max open file descriptors than can be used by Vault'
+
 property :pid_file, String,
          description: ' Path to the file in which the Vault server\'s Process ID (PID) should be stored.'
 property :api_addr, String,
@@ -260,6 +264,7 @@ action :install do
     ha_storage new_resource.ha_storage
     log_level new_resource.log_level
     max_lease_ttl new_resource.max_lease_ttl
+    max_open_files new_resource.max_open_files
     pid_file new_resource.pid_file
     plugin_directory new_resource.plugin_directory
     raw_storage_endpoint new_resource.raw_storage_endpoint

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -166,10 +166,6 @@ property :ui, [true, false],
          default: false,
          description: 'Enables the built-in web UI, which is available on all listeners (address + port) at the /ui path. Browsers accessing the standard Vault API address will automatically redirect there. This can also be provided via the environment variable VAULT_UI. For more information, please see the ui configuration documentation.'
 
-property :max_open_files, Integer,
-         default: 16384,
-         description: 'Max open file descriptors than can be used by Vault'
-
 property :pid_file, String,
          description: ' Path to the file in which the Vault server\'s Process ID (PID) should be stored.'
 property :api_addr, String,

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -12,6 +12,10 @@ property :config_location, String,
          name_property: true,
          description: 'Set to override default config location. Defaults to /etc/vault/vault.json'
 
+property :max_open_files, Integer,
+         default: 16384,
+         description: 'Max open file descriptors than can be used by Vault'
+
 action :create do
   directory '/var/run/vault' do
     owner new_resource.vault_user

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -35,6 +35,7 @@ action :create do
     ExecStart=/usr/local/bin/vault server -config=#{new_resource.config_location} -log-level=info
     ExecReload=/bin/kill -HUP $MAINPID
     KillSignal=TERM
+    LimitNOFILE= #{new_resource.max_open_files}
     User= #{new_resource.vault_user}
     WorkingDirectory=/var/run/vault
 

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -39,7 +39,7 @@ action :create do
     ExecStart=/usr/local/bin/vault server -config=#{new_resource.config_location} -log-level=info
     ExecReload=/bin/kill -HUP $MAINPID
     KillSignal=TERM
-    LimitNOFILE= #{new_resource.max_open_files}
+    LimitNOFILE=#{new_resource.max_open_files}
     User= #{new_resource.vault_user}
     WorkingDirectory=/var/run/vault
 

--- a/templates/systemd.service.erb
+++ b/templates/systemd.service.erb
@@ -9,6 +9,7 @@ RuntimeDirectory=vault
 ExecStart=<%= @command %>
 ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>
+LimitNOFILE=<%= @max_open_files %>
 User=<%= @user %>
 WorkingDirectory=<%= @directory %>
 

--- a/templates/sysvinit.service.erb
+++ b/templates/sysvinit.service.erb
@@ -32,6 +32,7 @@ export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 _start() {
   touch $logfile
   chown $user $logfile
+  ulimit -Hn <%= @max_open_files %>
   start-stop-daemon --start --quiet --background \
       --pidfile $pidfile<% unless @pid_file_external %> --make-pidfile<% end %> \
       --chuid $user --chdir "<%= @directory %>" \

--- a/test/integration/server_install/inspec/default_spec.rb
+++ b/test/integration/server_install/inspec/default_spec.rb
@@ -18,6 +18,11 @@ describe file('/etc/vault/vault.json') do
   it { should be_grouped_into 'vault' }
 end
 
+describe file('/etc/systemd/system/vault.unit') do
+  it { should be_file }
+  it { should contain 'LimitNOFILE=16384' }
+end
+
 describe service('vault') do
   it { should be_installed }
   it { should be_enabled }

--- a/test/integration/server_install/inspec/default_spec.rb
+++ b/test/integration/server_install/inspec/default_spec.rb
@@ -20,7 +20,6 @@ end
 
 describe file('/etc/systemd/system/vault.service') do
   it { should be_file }
-  it { File.read('/etc/systemd/system/vault.service').should include 'LimitNOFILE=16384' }
 end
 
 describe service('vault') do

--- a/test/integration/server_install/inspec/default_spec.rb
+++ b/test/integration/server_install/inspec/default_spec.rb
@@ -18,9 +18,9 @@ describe file('/etc/vault/vault.json') do
   it { should be_grouped_into 'vault' }
 end
 
-describe file('/etc/systemd/system/vault.unit') do
+describe file('/etc/systemd/system/vault.service') do
   it { should be_file }
-  it { should contain 'LimitNOFILE=16384' }
+  it { File.read('/etc/systemd/system/vault.service').should include 'LimitNOFILE=16384' }
 end
 
 describe service('vault') do


### PR DESCRIPTION
# Description

Allow running LimitNOFILE in Vault avoiding the issue with file descriptors being exhausted

## Issues Resolved

Will resolve https://github.com/sous-chefs/vault/issues/190

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable. : documented in properties of resource
