### PR TITLE
Include config option 'unauthenticated_metrics_access'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased Changes
+
+- Added 'unauthenticated_metrics_access' config option
+
 ## 4.2.0 (2020-08-11)
 
 - Created hashicorp_vault_agent_install resource

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -100,6 +100,10 @@ property :tls_x_forwarded_for_reject_not_present, [true, false],
          default: true,
          description: 'If set false, if there is no X-Forwarded-For header or it is empty, the client address will be used as-is, rather than the client connection rejected.'
 
+property :unauthenticated_metrics_access, [true, false],
+         default: false,
+         description: 'If set false, /v1/sys/metrics telemetry endpoint will require authentication.'
+
 property :cluster_name, String,
          description: 'Specifies the identifier for the Vault cluster. If omitted, Vault will generate a value. When connecting to Vault Enterprise, this value will be used in the interface.'
 
@@ -190,6 +194,9 @@ action :configure do
     max_request_size: new_resource.tls_max_request_size,
     max_request_duration: new_resource.tls_max_request_duration,
     tls_disable: new_resource.tls_disable,
+    telemetry: {
+      unauthenticated_metrics_access: new_resource.unauthenticated_metrics_access,
+    },
   }
 
   tcp_hash['proxy_protocol_behavior']                   = new_resource.tls_proxy_protocol_behavior unless new_resource.tls_proxy_protocol_behavior.nil?

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -116,6 +116,10 @@ property :tls_x_forwarded_for_reject_not_present, [true, false],
          default: true,
          description: 'If set false, if there is no X-Forwarded-For header or it is empty, the client address will be used as-is, rather than the client connection rejected.'
 
+property :unauthenticated_metrics_access, [true, false],
+         default: false,
+         description: 'If set false, /v1/sys/metrics telemetry endpoint will require authentication.'
+
 property :cluster_name, String,
          description: 'Specifies the identifier for the Vault cluster. If omitted, Vault will generate a value. When connecting to Vault Enterprise, this value will be used in the interface.'
 
@@ -266,6 +270,7 @@ action :install do
     tls_x_forwarded_for_hop_skips new_resource.tls_x_forwarded_for_hop_skips
     tls_x_forwarded_for_reject_not_authorized new_resource.tls_x_forwarded_for_reject_not_authorized
     tls_x_forwarded_for_reject_not_present new_resource.tls_x_forwarded_for_reject_not_present
+    unauthenticated_metrics_access new_resource.unauthenticated_metrics_access
     sensitive new_resource.sensitive
   end
 


### PR DESCRIPTION
This PR adds option for unauthenticated metrics access to `/v1/sys/metrics`
https://www.vaultproject.io/docs/configuration/listener/tcp#unauthenticated_metrics_access
