### PR TITLE
support aarch64/i386/x86_64 architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Support ark installation for aarch64/i386/x86_64 architectures
+
 ## 5.1.0 - *2021-02-08*
 
 - Added ark installation method support for Amazon Linux

--- a/libraries/install.rb
+++ b/libraries/install.rb
@@ -2,18 +2,27 @@ module Vault
   module Cookbook
     module InstallHelpers
       def vault_source(version)
-        case node['platform_family']
-        when 'debian', 'rhel', 'suse', 'fedora', 'amazon'
-          platform = 'linux'
-        when 'windows'
-          platform = 'windows'
-        when 'mac_os_x'
-          platform = 'darwin'
-        else
-          raise ArgumentError, "vault_source: Unsupported platform family #{node['platform_family']}"
-        end
+        platform = case node['platform_family']
+                   when 'debian', 'rhel', 'suse', 'fedora', 'amazon'
+                     'linux'
+                   when 'windows'
+                     'windows'
+                   when 'mac_os_x'
+                     'darwin'
+                   else
+                     raise ArgumentError, "vault_source: Unsupported platform family #{node['platform_family']}"
+                   end
 
-        "https://releases.hashicorp.com/vault/#{version}/vault_#{version}_#{platform}_amd64.zip"
+        arch =  case node['kernel']['machine']
+                when 'aarch64'
+                  'arm64'
+                when 'i386'
+                  '386'
+                else
+                  'amd64'
+                end
+
+        "https://releases.hashicorp.com/vault/#{version}/vault_#{version}_#{platform}_#{arch}.zip"
       end
 
       def vault_supporting_packages


### PR DESCRIPTION
# Description

Support ark installation for `aarch64`/`i386`/`x86_64` architectures.
https://releases.hashicorp.com/vault/1.6.2/

## Issues Resolved

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
